### PR TITLE
Added bge embedder

### DIFF
--- a/classifier_free_guidance_pytorch/__init__.py
+++ b/classifier_free_guidance_pytorch/__init__.py
@@ -12,3 +12,5 @@ from classifier_free_guidance_pytorch.classifier_free_guidance_pytorch import (
 
 from classifier_free_guidance_pytorch.open_clip import OpenClipAdapter
 from classifier_free_guidance_pytorch.t5 import T5Adapter
+from classifier_free_guidance_pytorch.bge import BGEAdapter
+

--- a/classifier_free_guidance_pytorch/bge.py
+++ b/classifier_free_guidance_pytorch/bge.py
@@ -1,0 +1,57 @@
+from typing import List
+from beartype import beartype
+
+import torch
+import transformers 
+from transformers import AutoTokenizer, AutoModel,AutoConfig
+transformers.logging.set_verbosity_error()
+
+ 
+
+class BGEAdapter():
+    def __init__(
+        self,
+        name
+    ):
+        name = 'BAAI/bge-base-en-v1.5'
+        tokenizer = AutoTokenizer.from_pretrained(name)
+        model = AutoModel.from_pretrained(name)
+        self.Config = AutoConfig.from_pretrained(name)
+        
+        if torch.cuda.is_available():
+            model = model.to("cuda")  
+            
+        self.name =  name
+        self.model = model
+        self.tokenizer = tokenizer
+
+    @property
+    def dim_latent(self):
+        return self.Config.hidden_size
+
+    @property
+    def max_text_len(self):
+        return 512
+
+    @torch.no_grad()
+    @beartype
+    def embed_text(
+        self,
+        texts: List[str],
+        return_text_encodings = False,
+        output_device = None
+    ):
+         
+        encoded_input  = self.tokenizer(texts, padding=True, truncation=True, return_tensors='pt').to("cuda")
+ 
+        self.model.eval()
+         
+        with torch.no_grad():
+            model_output = self.model(**encoded_input)  
+            
+        if not return_text_encodings: 
+            sentence_embeddings = model_output[0][:, 0]
+            sentence_embeddings = torch.nn.functional.normalize(sentence_embeddings, p=2, dim=1)
+            return sentence_embeddings  # Return normalized CLS embedding
+
+        return model_output.last_hidden_state.to(output_device)

--- a/classifier_free_guidance_pytorch/classifier_free_guidance_pytorch.py
+++ b/classifier_free_guidance_pytorch/classifier_free_guidance_pytorch.py
@@ -16,6 +16,7 @@ from inspect import signature
 from classifier_free_guidance_pytorch.t5 import T5Adapter
 from classifier_free_guidance_pytorch.open_clip import OpenClipAdapter
 from classifier_free_guidance_pytorch.attend import Attend
+from classifier_free_guidance_pytorch.bge import BGEAdapter
 
 # constants
 
@@ -413,7 +414,8 @@ class CrossAttention(nn.Module):
 
 CONDITION_CONFIG = dict(
     t5 = T5Adapter,
-    clip = OpenClipAdapter
+    clip = OpenClipAdapter,
+    bge = BGEAdapter
 )
 
 MODEL_TYPES = CONDITION_CONFIG.keys()


### PR DESCRIPTION
I implemented [bge](https://huggingface.co/BAAI/bge-base-en) which is on the 7th place on the [SOTA embedding leaderboard](https://huggingface.co/spaces/mteb/leaderboard) which beats openai ada embedder (23th place).
I'd imagine that this would be a good model to support and have better performance then T5, I implemented the base version which has 109M parameters.

I tried using CLIP to train a text-to-3d model but it' quite bad, I tested the cosine similarity of **chair** and **table** using CLIP and it had a 99% similarity, the T5 and bge had 70% and 71%.
When there is a to high similarity the transformer wont be able to tell apart from a chair or table.