### PR TITLE
Added so the embeddings are actually dropped

### DIFF
--- a/classifier_free_guidance_pytorch/classifier_free_guidance_pytorch.py
+++ b/classifier_free_guidance_pytorch/classifier_free_guidance_pytorch.py
@@ -823,5 +823,16 @@ class TextEmbeddingReturner(Conditioner):
         if cond_drop_prob > 0.:
             prob_keep_mask = prob_mask_like((batch, 1), 1. - cond_drop_prob, device = self.device)
             mask = mask & prob_keep_mask
+             
+            b, length, dim = text_embeds.shape 
+            masked_lengths = mask.sum(dim=1).tolist()
+            
+            max_length = max(masked_lengths)
+            text_embeds_dropped = torch.full((b, max_length, dim), self.text_embed_pad_value, dtype=text_embeds.dtype, device=text_embeds.device) 
+            for i in range(b):
+                text_embeds_dropped[i, :masked_lengths[i]] = text_embeds[i, mask[i]]
+
+            mask = (text_embeds_dropped != self.text_embed_pad_value).any(dim = -1)
+            text_embeds = text_embeds_dropped
 
         return tuple(self.conditioners), TextCondReturn(text_embeds, mask)


### PR DESCRIPTION
At the moment the TextEmbeddingReturner just returns a mask where it given the % chance using cond_drop_prob, is setting some mask values to false.

This works great if the model you are working with respects the mask, however x-transformers attention does not do this since it takes the context and uses the raw context and feeds it to the k and v linear layers.

https://github.com/lucidrains/x-transformers/blob/0c6266ee44ea99a4449cd9201ba55924a6a7eae7/x_transformers/x_transformers.py#L944

``` 
kv_input = default(context, x)

q_input = x
k_input = kv_input
v_input = kv_input
r_input = x 

q = self.to_q(q_input)
k = self.to_k(k_input)
v = self.to_v(v_input) if exists(self.to_v) else k
r = self.to_r(r_input) if exists(self.to_r) else None 
```