### PR TITLE
Changing clip model from laion400m_e32 to default

### DIFF
--- a/classifier_free_guidance_pytorch/open_clip.py
+++ b/classifier_free_guidance_pytorch/open_clip.py
@@ -11,7 +11,7 @@ from classifier_free_guidance_pytorch.tokenizer import tokenizer
 # constants
 
 DEFAULT_CLIP_NAME = 'ViT-B-32'
-DEFAULT_PRETRAINED_CLIP = 'laion400m_e32'
+DEFAULT_PRETRAINED_CLIP = 'openai'
 
 # helper functions
 


### PR DESCRIPTION
I think the openai is a better choice for most tasks, I've tried the laion2b_s34b_b79k but it seems like those models have issues with small syntax differences e.g. "a chair" and "chair"-

```

openai
==========
chair & a chair
0.9804482460021973
table & chair
0.8566312193870544
curved table & curved chair
0.8961982727050781
flat table & flat chair
0.8455690741539001
flat table & curved chair
0.7259061336517334
==========
 
laion400m_e32
==========
chair & a chair
0.6290445327758789
table & chair
0.9999410510063171
curved table & curved chair
1.0000001192092896
flat table &  flat chair
1.000000238418579
flat table &  curved chair
0.9999337196350098
==========

laion2b_s34b_b79k  
==========
chair & a chair
0.937156081199646
table & chair
0.7278417944908142
curved table &  curved chair
0.85465407371521
flat table & flat chair
0.8173342943191528
flat table & curved chair
0.6616789698600769 
==========
```