### PR TITLE
Tokenizer missing CLS & EOS

### DIFF
--- a/classifier_free_guidance_pytorch/open_clip.py
+++ b/classifier_free_guidance_pytorch/open_clip.py
@@ -6,7 +6,6 @@ from torch import nn, einsum
 import torch.nn.functional as F
 
 import open_clip
-from classifier_free_guidance_pytorch.tokenizer import tokenizer
 
 # constants
 

--- a/classifier_free_guidance_pytorch/open_clip.py
+++ b/classifier_free_guidance_pytorch/open_clip.py
@@ -41,7 +41,7 @@ class OpenClipAdapter():
         self.clip = clip
         clip.eval()
 
-        self.tokenizer = tokenizer
+        self.tokenizer = open_clip.get_tokenizer(name)
         self.text_embed_pad_value = text_embed_pad_value
 
         self.eos_id = 49407
@@ -82,7 +82,8 @@ class OpenClipAdapter():
         return_text_encodings = False,
         output_device = None
     ):
-        texts, max_length = self.tokenizer.tokenize(texts)
+        texts = self.tokenizer(texts)
+        max_length = (texts != 0).sum(dim=1)
         texts = texts[..., :self.max_text_len]
 
         text_embeds = self.clip.encode_text(texts)

--- a/classifier_free_guidance_pytorch/open_clip.py
+++ b/classifier_free_guidance_pytorch/open_clip.py
@@ -82,7 +82,7 @@ class OpenClipAdapter():
         output_device = None
     ):
         texts = self.tokenizer(texts)
-        max_length = (texts != 0).sum(dim=1)
+        max_length = (texts != 0).sum(dim=1).max().item()
         texts = texts[..., :self.max_text_len]
 
         text_embeds = self.clip.encode_text(texts)


### PR DESCRIPTION
I was wondering why I was unable to get results using the OpenClipAdapter, I was getting much better results with implementing & testing open_clip's functions outside of the class.

I checked out the output from the tokenizer and it seems like it's missing CLS and EOS which are added by the original tokenizer. 
These tokens seems to be very important since the results improved quite a lot. 

Tokenizer outputs:
classifier_free_guidance_pytorch.tokenizer: `4269`, 
open_clip.get_tokenizer("ViT-B-32"): `49406,  4269, 49407,`

I could make changes and insert the CLS and EOS into the tensor but since you can change the model using the kwargs, I don't think that is the best way in case not all the CLIP models uses the exact same tokenizer.

laion400m_e32
Using: open_clip.get_tokenizer("ViT-B-32")
```
Calling with: return_text_encodings = False

chair & a chair
0.9584068655967712
table & chair
0.7539879083633423
curved table & curved chair
0.8386579155921936
flat table & flat chair
0.8263269662857056
flat table & curved chair
0.6225502490997314
 
Calling with: return_text_encodings = True 

chair & a chair
0.9302060008049011
table & chair
0.7902950048446655
curved table & curved chair
0.8823343515396118
flat table & flat chair
0.8739901781082153
flat table & curved chair
0.6474944353103638
```

Using: classifier_free_guidance_pytorch.tokenizer 
```
Calling with: return_text_encodings = False  

chair & a chair
0.6290445327758789
table & chair
0.9999410510063171
curved table & curved chair
1.0000001192092896
flat table & flat chair
1.000000238418579
flat table & curved chair
0.9999337196350098 

Calling with: return_text_encodings = True 

chair & a chair
0.8913772106170654
table & chair
0.9999397397041321
curved table & curved chair
0.851962685585022
flat table & flat chair
0.848778486251831
flat table & curved chair
0.8365158438682556
```